### PR TITLE
Added better exception messages for ReflectionTypeLoadException.

### DIFF
--- a/Migr8.Npgsql/Migr8.Npgsql.csproj
+++ b/Migr8.Npgsql/Migr8.Npgsql.csproj
@@ -58,6 +58,9 @@
     <Compile Include="..\Migr8\Internals\DatabaseMigratorCore.cs">
       <Link>Internals\DatabaseMigratorCore.cs</Link>
     </Compile>
+    <Compile Include="..\Migr8\Internals\ExceptionHelper.cs">
+      <Link>Internals\ExceptionHelper.cs</Link>
+    </Compile>
     <Compile Include="..\Migr8\Internals\IDb.cs">
       <Link>Internals\IDb.cs</Link>
     </Compile>

--- a/Migr8/Internals/ExceptionHelper.cs
+++ b/Migr8/Internals/ExceptionHelper.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+using System.Text;
+
+namespace Migr8.Internals
+{
+	public static class ExceptionHelper
+	{
+		/// <summary>
+		/// Builds up a message, using the Message field of the specified exception
+		/// as well as any InnerExceptions. 
+		/// </summary>
+		/// <param name="exception">The exception.</param>
+		/// <returns>A combined message string.</returns>
+		public static string BuildMessage(Exception exception)
+		{
+			const bool isFriendlyMessage = false;
+			return BuildMessage(exception, isFriendlyMessage);
+		}
+
+		/// <summary>
+		/// Builds up a message, using the Message field of the specified exception
+		/// as well as any InnerExceptions. Excludes exception names, creating more readable message
+		/// </summary>
+		/// <param name="exception">The exception.</param>
+		/// <returns>A combined message string.</returns>
+		public static string BuildFriendlyMessage(Exception exception)
+		{
+			const bool isFriendlyMessage = true;
+			return BuildMessage(exception, isFriendlyMessage);
+		}
+
+		/// <summary>
+		/// Builds up a message, using the Message field of the specified exception
+		/// as well as any InnerExceptions.
+		/// </summary>
+		/// <param name="exception">The exception.</param>
+		/// <returns>A combined stack trace.</returns>
+		public static string BuildStackTrace(Exception exception)
+		{
+			StringBuilder sb = new StringBuilder(GetStackTrace(exception));
+
+			foreach (Exception inner in FlattenExceptionHierarchy(exception))
+			{
+				sb.Append(Environment.NewLine);
+				sb.Append("--");
+				sb.Append(inner.GetType().Name);
+				sb.Append(Environment.NewLine);
+				sb.Append(GetStackTrace(inner));
+			}
+
+			return sb.ToString();
+		}
+
+		/// <summary>
+		/// Gets the stack trace of the exception.
+		/// </summary>
+		/// <param name="exception">The exception.</param>
+		/// <returns>A string representation of the stack trace.</returns>
+		public static string GetStackTrace(Exception exception)
+		{
+			try
+			{
+				return exception.StackTrace;
+			}
+			catch (Exception)
+			{
+				return "No stack trace available";
+			}
+		}
+
+		private static string BuildMessage(Exception exception, bool isFriendlyMessage)
+		{
+			StringBuilder sb = new StringBuilder();
+			WriteException(sb, exception, isFriendlyMessage);
+
+			foreach (Exception inner in FlattenExceptionHierarchy(exception))
+			{
+				sb.Append(Environment.NewLine);
+				sb.Append("  ----> ");
+				WriteException(sb, inner, isFriendlyMessage);
+			}
+
+			return sb.ToString();
+		}
+
+		private static void WriteException(StringBuilder sb, Exception inner, bool isFriendlyMessage)
+		{
+			if (!isFriendlyMessage)
+			{
+				sb.AppendFormat(CultureInfo.CurrentCulture, "{0} : ", inner.GetType().ToString());
+			}
+			sb.Append(inner.Message);
+		}
+
+		private static List<Exception> FlattenExceptionHierarchy(Exception exception)
+		{
+			var result = new List<Exception>();
+
+			if (exception is ReflectionTypeLoadException)
+			{
+				var reflectionException = exception as ReflectionTypeLoadException;
+				result.AddRange(reflectionException.LoaderExceptions);
+
+				foreach (var innerException in reflectionException.LoaderExceptions)
+					result.AddRange(FlattenExceptionHierarchy(innerException));
+			}
+
+			if (exception is AggregateException)
+            {
+                var aggregateException = (exception as AggregateException);
+                result.AddRange(aggregateException.InnerExceptions);
+
+                foreach (var innerException in aggregateException.InnerExceptions)
+                    result.AddRange(FlattenExceptionHierarchy(innerException));
+            }
+            else
+
+			if (exception.InnerException != null)
+			{
+				result.Add(exception.InnerException);
+				result.AddRange(FlattenExceptionHierarchy(exception.InnerException));
+			}
+
+			return result;
+		}
+	}
+}

--- a/Migr8/Internals/Scanners/AssemblyScanner.cs
+++ b/Migr8/Internals/Scanners/AssemblyScanner.cs
@@ -16,24 +16,32 @@ namespace Migr8.Internals.Scanners
 
         public IEnumerable<IExecutableSqlMigration> GetMigrations()
         {
-            return _assembly
-                .GetTypes()
-                .Select(t => new
-                {
-                    Type = t,
-                    Attribute = t.GetCustomAttributes(typeof(MigrationAttribute), false)
-                        .Cast<MigrationAttribute>()
-                        .FirstOrDefault()
-                })
-                .Where(a => a.Attribute != null)
-                .Select(a => new
-                {
-                    Type = a.Type,
-                    Attribute = a.Attribute,
-                    Instance = CreateSqlMigrationInstance(a.Type)
-                })
-                .Select(a => CreateExecutableSqlMigration(a.Attribute, a.Instance))
-                .ToList();
+	        try
+	        {
+		        return _assembly
+			        .GetTypes()
+			        .Select(t => new
+			        {
+				        Type = t,
+				        Attribute = t.GetCustomAttributes(typeof(MigrationAttribute), false)
+					        .Cast<MigrationAttribute>()
+					        .FirstOrDefault()
+			        })
+			        .Where(a => a.Attribute != null)
+			        .Select(a => new
+			        {
+				        Type = a.Type,
+				        Attribute = a.Attribute,
+				        Instance = CreateSqlMigrationInstance(a.Type)
+			        })
+			        .Select(a => CreateExecutableSqlMigration(a.Attribute, a.Instance))
+			        .ToList();
+
+	        }
+	        catch (Exception exception)
+	        {
+		        throw new MigrationException(ExceptionHelper.BuildMessage(exception));
+	        }
         }
 
         static ISqlMigration CreateSqlMigrationInstance(Type type)

--- a/Migr8/Migr8.csproj
+++ b/Migr8/Migr8.csproj
@@ -49,6 +49,7 @@
   <ItemGroup>
     <Compile Include="Database_Sql.cs" />
     <Compile Include="Db.cs" />
+    <Compile Include="Internals\ExceptionHelper.cs" />
     <Compile Include="SqlServer\SqlServerDb.cs" />
     <Compile Include="Internals\IDb.cs" />
     <Compile Include="Internals\IExclusiveDbConnection.cs" />


### PR DESCRIPTION
When Migr8 is not able to find referenced types, i.e. `Assembly.GetTypes()`, a `ReflectionTypeLoadException` is thrown. By default the following exception message is shown:

![image](https://cloud.githubusercontent.com/assets/1128822/25358661/8e972fb0-2942-11e7-9d06-8bc3138dfa08.png)

Not very debug-friendly.

This PR has added a static `ExceptionHelper` class with methods for printing a prettified text for `ReflectionTypeLoadException` based on type and message:

![image](https://cloud.githubusercontent.com/assets/1128822/25358757/e99b8e92-2942-11e7-917d-cc576ebebfb3.png)

Much better!