### PR TITLE
Fix integration tests for MySQL

### DIFF
--- a/Migr8.Mysql.Test/AnotherMySqlTest.cs
+++ b/Migr8.Mysql.Test/AnotherMySqlTest.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+﻿using System.IO;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
 
 namespace Migr8.Mysql.Test
 {
@@ -8,7 +10,8 @@ namespace Migr8.Mysql.Test
         [Test]
         public void TryWithFiles()
         {
-            Database.Migrate(TestConfig.MysqlConnectionString, Migrations.FromFilesIn("Scripts"), new Options(logAction: Log, verboseLogAction: LogVerbose));
+            var directory = Path.Combine(TestContext.CurrentContext.TestDirectory, "Scripts");
+            Database.Migrate(TestConfig.MysqlConnectionString, Migrations.FromFilesIn(directory), new Options(logAction: Log, verboseLogAction: LogVerbose));
         }
     }
 }

--- a/Migr8.Mysql.Test/MysqlFixtureBase.cs
+++ b/Migr8.Mysql.Test/MysqlFixtureBase.cs
@@ -21,7 +21,7 @@ namespace Migr8.Mysql.Test
 
         public static void ResetDatabase()
         {
-            foreach (var tableName in GetTableNames())
+            foreach (var tableName in GetTableNames(false))
             {
                 DropTable(tableName);
             }

--- a/Migr8.Mysql.Test/MysqlIntegrationTest.cs
+++ b/Migr8.Mysql.Test/MysqlIntegrationTest.cs
@@ -17,7 +17,7 @@ namespace Migr8.Mysql.Test
             {
                 new TestMigration(1, "master", @"
 CREATE TABLE `bimmelim` (
-    `Id` BIGINT NOT NULL,
+    `Id` BIGINT  NOT NULL AUTO_INCREMENT,
 	`text` TEXT,
 	PRIMARY KEY (`Id`)
 );

--- a/Migr8.Mysql.Test/Scripts/001-master.sql
+++ b/Migr8.Mysql.Test/Scripts/001-master.sql
@@ -6,3 +6,5 @@ CREATE TABLE `Bimse` (
 	`Data` TEXT,
 	PRIMARY KEY (`Id`)
 );
+
+DROP TABLE `Bimse`;

--- a/Migr8.Mysql.Test/Scripts/002-master.sql
+++ b/Migr8.Mysql.Test/Scripts/002-master.sql
@@ -5,3 +5,5 @@ CREATE TABLE `Bimse2` (
 	`Data` TEXT,
 	PRIMARY KEY (`Id`)
 );
+
+DROP TABLE `Bimse2`;


### PR DESCRIPTION
Hi @mookid8000 here is the fix.
While working on this, I found some things like:
- There is no way to specify transaction per session and not per migration
- Each migration will open a new connection to the db
- SQL server package is on the main dll

Questions: what are your plans on this library? I would like to participate with some of the topics above if you are open to that.